### PR TITLE
ダッシュボードページのヘッターから作成

### DIFF
--- a/src/app/(dashboard)/dashboard/layout.tsx
+++ b/src/app/(dashboard)/dashboard/layout.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+
+//layout.tsxから取ってくる
+export default function DashboardLayout({
+    children,
+}: Readonly<{
+    children: React.ReactNode;
+}>) {
+    return (
+        <div>
+            {/* header */}
+            <header className="sticky top-0 z-40 border-b bg-background">
+                <div className="container flex items-center h-16 px-4">
+                    <Link href="/">
+                        <h1 className="text-lg font-bold">AI Image Generator</h1>
+                    </Link>
+                </div>
+            </header>
+            {/* dashboard */}
+            <div>
+                {/* sidebar */}
+                <aside>
+                    <div></div>
+                </aside>
+                {/* main contents */}
+                <main>{children}</main> {/*childrenの中身はpage.tsx*/}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
- AI Image Generatorをクリックするとホーム画面へ遷移

- 内容
sticky (固定)
z-40(z-index: 40を設定 他の要素より前面に表示（重ね順の制御） 数字が大きいほど手前に表示されます)

<img width="1440" height="677" alt="スクリーンショット 2025-10-07 4 16 14" src="https://github.com/user-attachments/assets/e35a5d60-e000-450f-8d20-d0ceeb53f67d" />
