### PR TITLE
ナビゲーションとメインコンテンツをCSSでスタイリング

### DIFF
--- a/src/app/(dashboard)/dashboard/layout.tsx
+++ b/src/app/(dashboard)/dashboard/layout.tsx
@@ -17,13 +17,15 @@ export default function DashboardLayout({
                 </div>
             </header>
             {/* dashboard */}
-            <div>
+            <div className="container md:grid md:grid-cols-[220px_minmax(0,1fr)] md:gap-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-10">
                 {/* sidebar */}
-                <aside>
-                    <div></div>
+                <aside className="fixed md:sticky top-16 z-30 hidden md:block border-r h-[calc(100vh-4.1rem)]">
+                    <div className="py-6 px-2 lg:py-8">Dashboard Navigation</div>
                 </aside>
                 {/* main contents */}
-                <main>{children}</main> {/*childrenの中身はpage.tsx*/}
+                <main className="flex w-full flex-col overflow-hidden p-4">
+                    {children} {/*childrenの中身はpage.tsx*/}
+                </main> 
             </div>
         </div>
     );


### PR DESCRIPTION
### ダッシュボードコンテナ
```
<div className="container md:grid md:grid-cols-[220px_minmax(0,1fr)] md:gap-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-10">
```
- container
コンテンツを中央揃えにし、最大幅を制限

- md:grid
中サイズ画面（768px以上）でグリッドレイアウトを適用
それ以下は通常のフロー（縦並び）

- md:grid-cols-[220px_minmax(0,1fr)]
カスタムグリッド列定義
220px: サイドバーの固定幅
minmax(0,1fr): メインコンテンツが残りのスペースを占有（最小0、最大1fr）
minmax(0,1fr)の0は重要：コンテンツがはみ出さないようにする

- md:gap-6 / lg:gap-10
グリッド列間の間隔
md（中画面）: 1.5rem (24px)
lg（大画面）: 2.5rem (40px)

- lg:grid-cols-[240px_minmax(0,1fr)]
大画面ではサイドバーを240pxに拡大

### サイドバー
```
<aside className="fixed md:sticky top-16 z-30 hidden md:block border-r h-[calc(100vh-4.1rem)]">
```
- ```fixed / md:sticky```
小画面: fixed（画面に完全固定）
中画面以上: sticky（スクロールに追従）

- ```top-16```

上から4rem (64px) の位置に配置
ヘッダーの高さ分（h-16）だけ下に配置

- ```z-30```
z-index: 30（重ね順）
ヘッダー（z-40）より後ろ、コンテンツより前

- ```hidden md:block```

小画面: 非表示
中画面以上: 表示

- ```border-r```
右側にボーダー（区切り線）

- ```h-[calc(100vh-4.1rem)]```
カスタム高さ計算
100vh: 画面の高さ100%
-4.1rem: ヘッダー分を引く（約65.6px）
サイドバーがヘッダーを除いた画面全体の高さになる

- ```py-6 px-2 lg:py-8```

py-6: 上下パディング 1.5rem
px-2: 左右パディング 0.5rem
lg:py-8: 大画面では上下パディング 2rem

### メインコンテンツ
```
<main className="flex w-full flex-col overflow-hidden p-4">
```
- ```flex flex-col```
フレックスボックスで縦並びレイアウト

- ```w-full```
幅100%（親要素いっぱいに広がる）

- ```overflow-hidden```
はみ出たコンテンツを隠す
グリッドのminmax(0,1fr)と組み合わせて、コンテンツの溢れを防ぐ

- ```p-4```
全方向のパディング 1rem (16px)

### 全体の動作：
- 小画面: サイドバー非表示、メインコンテンツのみ
- 中画面: 220px固定サイドバー + 可変メインコンテンツ
- 大画面: 240px固定サイドバー + 可変メインコンテンツ（間隔も広がる）

<img width="1438" height="772" alt="スクリーンショット 2025-10-09 1 00 59" src="https://github.com/user-attachments/assets/ecf25b29-6920-4ff7-8da2-3e07aed0d14b" />
