### PR TITLE
動的ルーティングのパラメーターを取得する時は、非同期で取得する

### DIFF
--- a/src/app/(dashboard)/dashboard/tools/[tools]/page.tsx
+++ b/src/app/(dashboard)/dashboard/tools/[tools]/page.tsx
@@ -1,7 +1,7 @@
 import { tools } from '@/config/tools'
 
-const ToolPage = ({params}: {params:{tool:string}}) => {
-    const toolType = params.tools as ToolType
+const ToolPage = async ({ params }: {params:Promise<{ tool:string }>}) => {
+    const toolType = (await params).tools as ToolType
     const tool = tools[toolType];
     return (
         <div>

--- a/src/app/(dashboard)/dashboard/tools/[tools]/page.tsx
+++ b/src/app/(dashboard)/dashboard/tools/[tools]/page.tsx
@@ -3,6 +3,12 @@ import { tools } from '@/config/tools'
 const ToolPage = async ({ params }: {params:Promise<{ tool:string }>}) => {
     const toolType = (await params).tools as ToolType
     const tool = tools[toolType];
+
+    //toolがない時はnot foundページを表示
+    if(!tool){
+        notFound()
+    }
+
     return (
         <div>
             <h1>{tool.title}</h1>

--- a/src/app/(dashboard)/dashboard/tools/[tools]/page.tsx
+++ b/src/app/(dashboard)/dashboard/tools/[tools]/page.tsx
@@ -1,7 +1,8 @@
 import { tools } from '@/config/tools'
 
-const ToolPage = () => {
-    const tool = tools["image-generator"];
+const ToolPage = ({params}: {params:{tool:string}}) => {
+    const toolType = params.tools
+    const tool = tools[toolType];
     return (
         <div>
             <h1>{tool.title}</h1>

--- a/src/app/(dashboard)/dashboard/tools/[tools]/page.tsx
+++ b/src/app/(dashboard)/dashboard/tools/[tools]/page.tsx
@@ -1,7 +1,7 @@
 import { tools } from '@/config/tools'
 
 const ToolPage = ({params}: {params:{tool:string}}) => {
-    const toolType = params.tools
+    const toolType = params.tools as ToolType
     const tool = tools[toolType];
     return (
         <div>

--- a/src/config/tools.ts
+++ b/src/config/tools.ts
@@ -12,7 +12,7 @@ export const tools = {
         component:ImageGenerator
     },
     optimize: {
-        title:"画像最適化",
+        title:"画像圧縮",
         description:"画像を最適化してサイズを縮小",
         component:ImageGenerator
     },

--- a/src/config/tools.ts
+++ b/src/config/tools.ts
@@ -17,3 +17,5 @@ export const tools = {
         component:ImageGenerator
     },
 }
+
+export type ToolType = keyof typeof tools;


### PR DESCRIPTION
<img width="1439" height="743" alt="スクリーンショット 2025-10-14 22 48 06" src="https://github.com/user-attachments/assets/f0a4175d-968f-45fb-9035-89629e8616b6" />

<img width="1436" height="765" alt="スクリーンショット 2025-10-14 22 48 17" src="https://github.com/user-attachments/assets/05d80e95-8887-43a6-bce1-eb45a2e686c0" />

<img width="1436" height="727" alt="スクリーンショット 2025-10-14 22 48 28" src="https://github.com/user-attachments/assets/b731245c-5abb-4397-88bf-cc2c499d04ea" />

- toolsが何もない時
<img width="1436" height="680" alt="スクリーンショット 2025-10-14 22 48 45" src="https://github.com/user-attachments/assets/26cd1392-7437-4d06-9c25-96b13089cbce" />
